### PR TITLE
Fix commandhelper overwriting r2api.utils.commandhelper when depending on minirpclib

### DIFF
--- a/Utilities/CommandHelper.cs
+++ b/Utilities/CommandHelper.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using RoR2;
 
-public class CommandHelper
+internal class CommandHelper
 {
     public static void RegisterCommands(RoR2.Console self)
     {


### PR DESCRIPTION
Alternatively, since it's already depending on r2api, it could use r2api's commandhelper instead.